### PR TITLE
Add #beginners channel to greeter message

### DIFF
--- a/greeter.md
+++ b/greeter.md
@@ -4,6 +4,8 @@ Please take a minute to make sure you've read the Code of Conduct: https://githu
 
 If you'd like, introduce yourself in #introductions then see if there are any other communities you'd like to join.
 
+If you’re new to tech, consider joining the #beginners channel, where every question is welcome.
+
 For #announcements requests and general queries you can message #asktheadmins.
 
 :v:


### PR DESCRIPTION
We've started a #beginners channel, a space where no question is too stupid and no one will be embarrassed to ask a question, any question, about tech.
It'd be swell if the greeter mentioned that newbies can join it (since there are a lot of young programmers joining).